### PR TITLE
README.md: correct URL of original Swapchain recreation C++

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ The shaders are compiled into SPIRV at runtime using [*shaderc*](https://github.
 
 [Read the tutorial](https://vulkan-tutorial.com/Drawing_a_triangle/Swap_chain_recreation)
 
-![c++](cpp_icon.png)[Original code](https://github.com/Overv/VulkanTutorial/blob/master/code/16_swap_chain_recreation.cpp)
+![c++](cpp_icon.png)[Original code](https://github.com/Overv/VulkanTutorial/blob/master/code/17_swap_chain_recreation.cpp)
 
 ![java](java_icon.png)[Java code](src/main/java/javavulkantutorial/Ch16SwapChainRecreation.java)
 


### PR DESCRIPTION
While working through this excellent tutorial, I discovered an incorrect URL, which led me to "404 - page not found".

This pull request corrects the URL.